### PR TITLE
Add mandatory heartbeat from client to server

### DIFF
--- a/client/socket-redis.js
+++ b/client/socket-redis.js
@@ -34,7 +34,7 @@ var SocketRedis = (function() {
           }
         }
         closeStamp = null;
-        handler.onopen.call(handler)
+        handler._onopen.call(handler)
       };
       sockJS.onmessage = function(event) {
         var data = JSON.parse(event.data);
@@ -45,7 +45,7 @@ var SocketRedis = (function() {
       sockJS.onclose = function() {
         closeStamp = new Date().getTime();
         retry();
-        handler.onclose.call(handler);
+        handler._onclose.call(handler);
       };
     });
 
@@ -104,10 +104,18 @@ var SocketRedis = (function() {
   };
 
   Client.prototype.onopen = function() {
-    this._startHeartbeat();
   };
 
   Client.prototype.onclose = function() {
+  };
+
+  Client.prototype._onopen = function() {
+    this._startHeartbeat();
+    this.onopen.call(this);
+  };
+
+  Client.prototype._onclose = function() {
+    this.onclose.call(this);
     this._stopHeartbeat();
   };
 

--- a/client/socket-redis.js
+++ b/client/socket-redis.js
@@ -104,9 +104,22 @@ var SocketRedis = (function() {
   };
 
   Client.prototype.onopen = function() {
+    this._startHeartbeat();
   };
 
   Client.prototype.onclose = function() {
+    this._stopHeartbeat();
+  };
+
+  Client.prototype._startHeartbeat = function() {
+    this._heartbeatTimeout = setTimeout(function() {
+      sockJS.send(JSON.stringify({event: 'heartbeat'}));
+      this._startHeartbeat();
+    }.bind(this), 25 * 1000);
+  };
+
+  Client.prototype._stopHeartbeat = function() {
+    clearTimeout(this._heartbeatTimeout);
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-redis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Redis to SockJS relay",
   "main": "socket-redis.js",
   "bin": {


### PR DESCRIPTION
Addressing https://github.com/cargomedia/puppet-packages/pull/1368

Unfortunately Sock.js [doesn't implement a proper heartbeat mechanism](https://github.com/sockjs/sockjs-protocol/wiki/Heartbeats-and-SockJS). As a result dead connections can pile up.

Idea:
1. Let clients send a regular heartbeat message every 25 seconds
2. On the server process those heartbeats, and close connections that didn't send a heartbeat after 1000 seconds

For this change we first need to adjust our clients to send the heartbeats:
- socket-redis: See [client/socket-redis.js](https://github.com/cargomedia/socket-redis/blob/master/client/socket-redis.js)
 - Copy [in CM](https://github.com/cargomedia/cm/blob/master/client-vendor/after-body/socket-redis/socket-redis.js)
- studio-agent: this is already happening, see [client.rb](https://github.com/cargomedia/rndmvr-studio_agent/blob/master/lib/socket_redis/client.rb#L9).

Note that the socket-redis server *already knows* about a "heartbeat" message (because it's sent from studio-agent), but is just ignoring it, see [worker.js](https://github.com/cargomedia/socket-redis/blob/master/lib/worker.js#L250).

@vogdb maybe for you?
cc @tomaszdurka @kris-lab 