### PR TITLE
Add mandatory heartbeat from client to server

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -35,7 +35,8 @@ module.exports = (function() {
     }
 
     sockjsServer = sockjs.createServer(sockjsOptions);
-    listen(port, sslOptions);
+    this._connections = {};
+    listen.call(this, port, sslOptions);
   }
 
   /**
@@ -54,6 +55,21 @@ module.exports = (function() {
         console.log("Invalid down event type: `" + type + "`");
         break;
     }
+  };
+
+  Worker.prototype._startTimeoutShutdown = function(connection) {
+    if (this._connections[connection]) {
+      this._stopTimeoutShutdown(connection);
+    }
+    this._connections[connection] = setTimeout(function() {
+      connection.removeAllListeners('data');
+      connection.close();
+    }.bind(this), 1000 * 1000);
+  };
+
+  Worker.prototype._stopTimeoutShutdown = function(connection) {
+    clearTimeout(this._connections[connection]);
+    this._connections[connection] = null;
   };
 
   /**
@@ -134,6 +150,7 @@ module.exports = (function() {
         console.error('Empty WebSocket connection');
         return;
       }
+      self._startTimeoutShutdown(connection);
 
       var connectionChannelIds = [];
 
@@ -253,6 +270,7 @@ module.exports = (function() {
                * If a client directly connects to the low level `/websocket` endpoint it
                * should send heartbeats itself from the client to the server.
                */
+              self._startTimeoutShutdown(connection);
               break;
 
             default:
@@ -267,6 +285,7 @@ module.exports = (function() {
         _.each(connectionChannelIds, function(channelId) {
           unsubscribe(channelId);
         });
+        self._stopTimeoutShutdown(connection);
       });
     });
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -35,7 +35,7 @@ module.exports = (function() {
     }
 
     sockjsServer = sockjs.createServer(sockjsOptions);
-    this._connections = {};
+    this._connectionTimeouts = {};
     listen.call(this, port, sslOptions);
   }
 
@@ -57,19 +57,19 @@ module.exports = (function() {
     }
   };
 
-  Worker.prototype._startTimeoutShutdown = function(connection) {
-    if (this._connections[connection]) {
-      this._stopTimeoutShutdown(connection);
+  Worker.prototype._startConnectionTimeout = function(connection) {
+    if (this._connectionTimeouts[connection]) {
+      this._stopConnectionTimeout(connection);
     }
-    this._connections[connection] = setTimeout(function() {
+    this._connectionTimeouts[connection] = setTimeout(function() {
       connection.removeAllListeners('data');
       connection.close();
     }.bind(this), 1000 * 1000);
   };
 
-  Worker.prototype._stopTimeoutShutdown = function(connection) {
-    clearTimeout(this._connections[connection]);
-    this._connections[connection] = null;
+  Worker.prototype._stopConnectionTimeout = function(connection) {
+    clearTimeout(this._connectionTimeouts[connection]);
+    this._connectionTimeouts[connection] = null;
   };
 
   /**
@@ -150,7 +150,7 @@ module.exports = (function() {
         console.error('Empty WebSocket connection');
         return;
       }
-      self._startTimeoutShutdown(connection);
+      self._startConnectionTimeout(connection);
 
       var connectionChannelIds = [];
 
@@ -270,7 +270,7 @@ module.exports = (function() {
                * If a client directly connects to the low level `/websocket` endpoint it
                * should send heartbeats itself from the client to the server.
                */
-              self._startTimeoutShutdown(connection);
+              self._startConnectionTimeout(connection);
               break;
 
             default:
@@ -285,7 +285,7 @@ module.exports = (function() {
         _.each(connectionChannelIds, function(channelId) {
           unsubscribe(channelId);
         });
-        self._stopTimeoutShutdown(connection);
+        self._stopConnectionTimeout(connection);
       });
     });
 


### PR DESCRIPTION
Addressing https://github.com/cargomedia/puppet-packages/pull/1368

Unfortunately Sock.js [doesn't implement a proper heartbeat mechanism](https://github.com/sockjs/sockjs-protocol/wiki/Heartbeats-and-SockJS). As a result dead connections can pile up.

Idea:
1. Let clients send a regular heartbeat message every 25 seconds
2. On the server process those heartbeats, and close connections that didn't send a heartbeat after 1000 seconds

For this change we first need to adjust our clients to send the heartbeats:
- socket-redis: See [client/socket-redis.js](https://github.com/cargomedia/socket-redis/blob/master/client/socket-redis.js)
 - Copy [in CM](https://github.com/cargomedia/cm/blob/master/client-vendor/after-body/socket-redis/socket-redis.js)
- studio-agent: this is already happening, see [client.rb](https://github.com/cargomedia/rndmvr-studio_agent/blob/master/lib/socket_redis/client.rb#L9).

Note that the socket-redis server *already knows* about a "heartbeat" message (because it's sent from studio-agent), but is just ignoring it, see [worker.js](https://github.com/cargomedia/socket-redis/blob/master/lib/worker.js#L250).

@vogdb maybe for you?
cc @tomaszdurka @kris-lab 