### PR TITLE
Lazily create channel when message is published

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -64,7 +64,8 @@ module.exports = (function() {
   var sendDownPublish = function(channelId, event, data) {
     var channel = channels[channelId];
     if (!channel) {
-      return;
+      channel = createChannel(channelId);
+      delayedCloseChannel(channelId);
     }
     var content = {channel: channelId, event: event, data: data};
     channel.msgs.push({timestamp: new Date().getTime(), content: content});
@@ -110,6 +111,30 @@ module.exports = (function() {
   };
 
   /**
+   * @param {Number} channelId
+   * @returns {Object} channel
+   */
+  var createChannel = function(channelId) {
+    channels[channelId] = {subscribers: [], msgs: [], closeTimeout: null};
+    return channels[channelId];
+  };
+
+  /**
+   * @param {Number} channelId
+   */
+  var delayedCloseChannel = function(channelId) {
+    var channel = channels[channelId];
+    if (channel) {
+      if (channel.closeTimeout) {
+        clearTimeout(channel.closeTimeout);
+      }
+      channel.closeTimeout = setTimeout(function() {
+        delete channels[channelId];
+      }, 10000);
+    }
+  };
+
+  /**
    * @return {Object}
    */
   var getChannelsData = function() {
@@ -151,9 +176,7 @@ module.exports = (function() {
           return subscriber.connection === connection;
         });
         if (channel.subscribers.length == 0) {
-          channel.closeTimeout = setTimeout(function() {
-            delete channels[channelId];
-          }, 10000);
+          delayedCloseChannel(channelId);
         }
       };
 
@@ -169,7 +192,7 @@ module.exports = (function() {
         msgStartTime = msgStartTime || new Date().getTime();
         connectionChannelIds.push(channelId);
         if (!channels[channelId]) {
-          channels[channelId] = {subscribers: [], msgs: [], closeTimeout: null};
+          createChannel(channelId);
         }
         var channel = channels[channelId];
         clearTimeout(channel.closeTimeout);
@@ -190,7 +213,8 @@ module.exports = (function() {
       var publish = function(channelId, event, data) {
         event = 'client-' + event;
         if (!channels[channelId]) {
-          return;
+          createChannel(channelId);
+          delayedCloseChannel(channelId);
         }
         process.send({type: 'publish', data: {channel: channelId, event: event, data: data}});
       };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -212,10 +212,6 @@ module.exports = (function() {
        */
       var publish = function(channelId, event, data) {
         event = 'client-' + event;
-        if (!channels[channelId]) {
-          createChannel(channelId);
-          delayedCloseChannel(channelId);
-        }
         process.send({type: 'publish', data: {channel: channelId, event: event, data: data}});
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-redis",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Redis to SockJS relay",
   "main": "socket-redis.js",
   "bin": {


### PR DESCRIPTION
Currently we silently drop messages that are published to channels that don't exit (`worker.js`: `sendDownPublish()`).

Idea: lazily create the channel in that case, to keep the message around, in case somebody connects to it in the next few seconds (then that client can receive those past messages).

Currently we are only creating channels when somebody subscribes to it (`worker.js`: `subscribe()`).

Special care needs to be taken to make sure we *clean up* channels that have a message published to them, but nobody ever subscribes to them. There is a similar mechanism in `worker.js`: `unsubscribe()` - start a timeout and delete the channel after 10 seconds if it's *unused*.

cc @zazabe 