### PR TITLE
Release heartbeat changes as breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-redis",
-  "version": "0.1.9",
+  "version": "2.0.0",
   "description": "Redis to SockJS relay",
   "main": "socket-redis.js",
   "bin": {


### PR DESCRIPTION
These changes do not work with old client, we should release them as breaking.

Means:
- do not release 0.1.9 version to npm