### PR TITLE
Use "destroy()" to close connection on missing heartbeat

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,8 +62,7 @@ module.exports = (function() {
       this._stopConnectionTimeout(connection);
     }
     this._connectionTimeouts[connection] = setTimeout(function() {
-      connection.removeAllListeners('data');
-      connection.close();
+      connection.destroy();
     }.bind(this), 1000 * 1000);
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket-redis",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Redis to SockJS relay",
   "main": "socket-redis.js",
   "bin": {


### PR DESCRIPTION
Mandatory heartbeat was added in: https://github.com/cargomedia/socket-redis/pull/72

Unfortunately it doesn't seem to work reliably. We still have connections open on socket-redis, that don't receive any data. See [investigation here](https://github.com/cargomedia/puppet-packages/pull/1368#issuecomment-239844620).

I think we should `destroy()` the `SockJSConnection`, instead of `close()`ing it.

@vogdb could you do the change?