### PR TITLE
Subscriber leak since 2.0.2

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,7 +62,8 @@ module.exports = (function() {
       this._stopConnectionTimeout(connection);
     }
     this._connectionTimeouts[connection] = setTimeout(function() {
-      connection.destroy();
+      connection.removeAllListeners('data');
+      connection.close();
     }.bind(this), 1000 * 1000);
   };
 


### PR DESCRIPTION
Steady increase in number of subscribers (and channels) since 2016-08-19, when version 2.0.2 was released.
Last 30 days:
<img src="https://cloud.githubusercontent.com/assets/360800/18033726/71422960-6d2c-11e6-959c-aa4d5b212e57.png" width=300>

The number of network connections is stable. So it's likely a socket-redis internal issue.
Last 7 days:
<img src="https://cloud.githubusercontent.com/assets/360800/18033856/2242e7da-6d2e-11e6-9867-aa36806c6ebe.png" width=300>

Restarting socket-redis gets rid of those susbcribers:
<img src="https://cloud.githubusercontent.com/assets/360800/18033871/7a0b7810-6d2e-11e6-97e1-b6299d55c315.png" width=300>

Version 2.0.2 updated to SockJS 0.3.17:
https://github.com/cargomedia/socket-redis/compare/2.0.1...2.0.2
(@vogdb side note: please use `git tag-push` to create a new tag, so we have the changelog in the tag)

@cargomedia/devops fyi
@vogdb @tomaszdurka could you investigate?
I guess we're not getting some "close" event, maybe due to the introduced forced timeout?